### PR TITLE
feat(model): handle cached extensions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/uptrace/bun/dialect/sqlitedialect v1.2.16
 	github.com/uptrace/bun/driver/sqliteshim v1.2.15
 	github.com/uptrace/bun/extra/bundebug v1.2.15
-	github.com/veraison/corim v1.1.3-0.20251209103150-ef6dbb7ed63f
+	github.com/veraison/corim v1.1.3-0.20251212144809-26e0f2a5f59d
 	github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff
 	github.com/veraison/swid v1.1.1-0.20251003121634-fd1f7f1e1897
 )

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/uptrace/bun/driver/sqliteshim v1.2.15 h1:M/rZJSjOPV4OmfTVnDPtL+wJmdMT
 github.com/uptrace/bun/driver/sqliteshim v1.2.15/go.mod h1:YqwxFyvM992XOCpGJtXyKPkgkb+aZpIIMzGbpaw1hIk=
 github.com/uptrace/bun/extra/bundebug v1.2.15 h1:IY2Z/pVyVg0ApWnQ/pEnwe6BWxlDDATCz7IFZghutCs=
 github.com/uptrace/bun/extra/bundebug v1.2.15/go.mod h1:JuE+BT7NjTZ9UKr74eC8s9yZ9dnQCeufDwFRTC8w3Xo=
-github.com/veraison/corim v1.1.3-0.20251209103150-ef6dbb7ed63f h1:ANVwskQLZ0YEzivFZqreGIftxakfd579fpOcjU8rHjo=
-github.com/veraison/corim v1.1.3-0.20251209103150-ef6dbb7ed63f/go.mod h1:96PQ0lk+O9bzutKTDz66G2DaARYUp1BeR06EYwEwSH0=
+github.com/veraison/corim v1.1.3-0.20251212144809-26e0f2a5f59d h1:ifSo+6zUb8I7yOBF1MgZflJwXmCYiZmiemd74VDcJW0=
+github.com/veraison/corim v1.1.3-0.20251212144809-26e0f2a5f59d/go.mod h1:96PQ0lk+O9bzutKTDz66G2DaARYUp1BeR06EYwEwSH0=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff h1:r6I2eJL/z8dp5flsQIKHMeDjyV6UO8If3MaVBLvTjF4=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/go-cose v1.2.1 h1:Gj4x20D0YP79J2+cK3anjGEMwIkg2xX+TKVVGUXwNAc=

--- a/pkg/model/extension_test.go
+++ b/pkg/model/extension_test.go
@@ -37,10 +37,14 @@ func TestExtensionValue_round_trip(t *testing.T) {
 
 	var original comid.Extensions
 	original.Register(&extStruct)
+	original.Cached = map[string]any{
+		"-1":  uint64(7),
+		"fum": false,
+	}
 
 	extVals, err := CoMIDExtensionsFromCoRIM(original)
 	assert.NoError(t, err)
-	assert.Len(t, extVals, 8)
+	assert.Len(t, extVals, 10)
 
 	for _, ev := range extVals {
 		ev.OwnerID = 1
@@ -53,7 +57,7 @@ func TestExtensionValue_round_trip(t *testing.T) {
 
 	err = db.NewSelect().Model(&resVals).Scan(ctx)
 	assert.NoError(t, err)
-	assert.Len(t, resVals, 8)
+	assert.Len(t, resVals, 10)
 
 	returnedExts, err := CoMIDExtensionsToCoRIM(resVals)
 	assert.NoError(t, err)
@@ -63,6 +67,8 @@ func TestExtensionValue_round_trip(t *testing.T) {
 	val, err := returnedExts.Get("Qux")
 	assert.NoError(t, err)
 	assert.Equal(t, map[interface{}]interface{}{"Zap": true}, val)
+
+	assert.Equal(t, original.Cached, returnedExts.Cached)
 }
 
 func TestExtensionValue_Select(t *testing.T) {


### PR DESCRIPTION
Update dependencies to the corim library that now caches unknown extensions. Extract cached extension values along side known extensions when converting.

An ExtensionValue represents a cached value if its FieldName is empty. In that case, JSONTag is set to the map key (which could be the stringified CBOR code point) ValueBytes are set to the CBOR-encoded value.