### PR TITLE
chore!: further API types normalization

### DIFF
--- a/cmd/corim-store/cmd/common.go
+++ b/cmd/corim-store/cmd/common.go
@@ -54,16 +54,15 @@ func AddEnviromentFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("group-id", "g", "", "Environment group ID")
 }
 
-func BuildEnvironment(cmd *cobra.Command) (*comid.Environment, error) {
-	var ret comid.Environment
-	var cls comid.Class
+func BuildEnvironment(cmd *cobra.Command) (*model.Environment, error) {
+	var ret model.Environment
 
 	vendor, err := cmd.Flags().GetString("vendor")
 	if err != nil {
 		return nil, fmt.Errorf("vendor: %w", err)
 	}
 	if vendor != "" {
-		cls.Vendor = &vendor
+		ret.Vendor = &vendor
 	}
 
 	model, err := cmd.Flags().GetString("model")
@@ -71,7 +70,7 @@ func BuildEnvironment(cmd *cobra.Command) (*comid.Environment, error) {
 		return nil, fmt.Errorf("model: %w", err)
 	}
 	if model != "" {
-		cls.Model = &model
+		ret.Model = &model
 	}
 
 	layerInt, err := cmd.Flags().GetInt64("layer")
@@ -80,7 +79,7 @@ func BuildEnvironment(cmd *cobra.Command) (*comid.Environment, error) {
 	}
 	if layerInt > -1 {
 		layer := uint64(layerInt)
-		cls.Layer = &layer
+		ret.Layer = &layer
 	}
 
 	indexInt, err := cmd.Flags().GetInt64("index")
@@ -89,7 +88,7 @@ func BuildEnvironment(cmd *cobra.Command) (*comid.Environment, error) {
 	}
 	if indexInt > -1 {
 		index := uint64(indexInt)
-		cls.Index = &index
+		ret.Index = &index
 	}
 
 	classIDText, err := cmd.Flags().GetString("class-id")
@@ -103,14 +102,10 @@ func BuildEnvironment(cmd *cobra.Command) (*comid.Environment, error) {
 			return nil, fmt.Errorf("class-id: %w", err)
 		}
 
-		cls.ClassID, err = comid.NewClassID(classIDBytes, classIDType)
-		if err != nil {
-			return nil, fmt.Errorf("class-id: %w", err)
+		ret.ClassBytes = &classIDBytes
+		if classIDType != "" {
+			ret.ClassType = &classIDType
 		}
-	}
-
-	if cls.ClassID != nil || cls.Vendor != nil || cls.Model != nil || cls.Layer != nil || cls.Index != nil {
-		ret.Class = &cls
 	}
 
 	instanceIDText, err := cmd.Flags().GetString("instance-id")
@@ -124,9 +119,9 @@ func BuildEnvironment(cmd *cobra.Command) (*comid.Environment, error) {
 			return nil, fmt.Errorf("instance-id: %w", err)
 		}
 
-		ret.Instance, err = comid.NewInstance(instanceIDBytes, instanceIDType)
-		if err != nil {
-			return nil, fmt.Errorf("instance-id: %w", err)
+		ret.InstanceBytes = &instanceIDBytes
+		if instanceIDType != "" {
+			ret.InstanceType = &instanceIDType
 		}
 	}
 
@@ -141,17 +136,13 @@ func BuildEnvironment(cmd *cobra.Command) (*comid.Environment, error) {
 			return nil, fmt.Errorf("group-id: %w", err)
 		}
 
-		ret.Group, err = comid.NewGroup(groupIDBytes, groupIDType)
-		if err != nil {
-			return nil, fmt.Errorf("group-id: %w", err)
+		ret.GroupBytes = &groupIDBytes
+		if groupIDType != "" {
+			ret.GroupType = &groupIDType
 		}
 	}
 
 	return &ret, nil
-}
-
-func EnvironmentIsEmpty(env *comid.Environment) bool {
-	return env.Class == nil && env.Instance == nil && env.Group == nil
 }
 
 func RenderEnviroment(env *model.Environment) (string, error) {

--- a/cmd/corim-store/cmd/get.go
+++ b/cmd/corim-store/cmd/get.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/veraison/corim-store/pkg/model"
-	"github.com/veraison/corim-store/pkg/store"
+	storemod "github.com/veraison/corim-store/pkg/store"
 	"github.com/veraison/corim/comid"
 )
 
@@ -51,7 +51,7 @@ func runGetCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if EnvironmentIsEmpty(env) {
+	if env.IsEmpty() {
 		return errors.New("at least one enviroment field specifier must be provided (see --help)")
 	}
 
@@ -65,7 +65,7 @@ func runGetCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	store, err := store.Open(context.Background(), cliConfig.Store())
+	store, err := storemod.Open(context.Background(), cliConfig.Store())
 	if err != nil {
 		return err
 	}
@@ -77,11 +77,7 @@ func runGetCommand(cmd *cobra.Command, args []string) error {
 		var found []*model.ValueTriple
 		var err error
 
-		if activeOnly {
-			found, err = store.GetActiveValueTriples(env, label, exact)
-		} else {
-			found, err = store.GetValueTriples(env, label, exact)
-		}
+		found, err = storemod.GetTripleModels[*model.ValueTriple](store, env, label, exact, activeOnly)
 
 		if err != nil {
 			return err
@@ -102,11 +98,7 @@ func runGetCommand(cmd *cobra.Command, args []string) error {
 		var found []*model.KeyTriple
 		var err error
 
-		if activeOnly {
-			found, err = store.GetActiveKeyTriples(env, label, exact)
-		} else {
-			found, err = store.GetKeyTriples(env, label, exact)
-		}
+		found, err = storemod.GetTripleModels[*model.KeyTriple](store, env, label, exact, activeOnly)
 
 		if err != nil {
 			return err

--- a/cmd/corim-store/cmd/list.go
+++ b/cmd/corim-store/cmd/list.go
@@ -10,9 +10,9 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim-store/pkg/store"
+	"github.com/veraison/corim-store/pkg/model"
+	storemod "github.com/veraison/corim-store/pkg/store"
 	"github.com/veraison/corim-store/pkg/util"
-	"github.com/veraison/corim/comid"
 )
 
 var listCmd = &cobra.Command{
@@ -48,7 +48,7 @@ func runListCommand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	store, err := store.Open(context.Background(), cliConfig.Store())
+	store, err := storemod.Open(context.Background(), cliConfig.Store())
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func runListCommand(cmd *cobra.Command, args []string) error {
 	var header []any
 	var rows [][]any
 
-	if what != "triples" && !EnvironmentIsEmpty(env) {
+	if what != "triples" && !env.IsEmpty() {
 		return errors.New("environment specifiers are only allowed for triples")
 	}
 
@@ -100,7 +100,7 @@ func runListCommand(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func listManifests(store *store.Store) ([]any, [][]any, error) {
+func listManifests(store *storemod.Store) ([]any, [][]any, error) {
 	columns := []string{"label", "manifest_id", "profile",
 		"not_before", "not_after", "digest", "time_added"}
 	retCols := make([]any, 0, len(columns)+1)
@@ -141,7 +141,7 @@ func listManifests(store *store.Store) ([]any, [][]any, error) {
 	return retCols, ret, nil
 }
 
-func listModuleTags(store *store.Store) ([]any, [][]any, error) {
+func listModuleTags(store *storemod.Store) ([]any, [][]any, error) {
 	columns := []string{"tag_id", "language", "manifest", "label"}
 	retCols := make([]any, 0, len(columns)+1)
 
@@ -179,7 +179,7 @@ func listModuleTags(store *store.Store) ([]any, [][]any, error) {
 	return retCols, ret, nil
 }
 
-func listEntities(store *store.Store) ([]any, [][]any, error) {
+func listEntities(store *storemod.Store) ([]any, [][]any, error) {
 	var matches []map[string]any
 	columns := []string{"name", "uri", "owner"}
 	retCols := make([]any, 0, len(columns)+1)
@@ -218,8 +218,8 @@ func listEntities(store *store.Store) ([]any, [][]any, error) {
 }
 
 func listTriples(
-	store *store.Store,
-	env *comid.Environment,
+	store *storemod.Store,
+	env *model.Environment,
 	label string,
 	exact bool,
 ) ([]any, [][]any, error) {
@@ -241,12 +241,12 @@ func listTriples(
 		lookup[match["id"].(int64)] = match
 	}
 
-	keyTriples, err := store.GetKeyTriples(env, label, exact)
+	keyTriples, err := storemod.GetTripleModels[*model.KeyTriple](store, env, label, exact, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting key triples: %w", err)
 	}
 
-	valueTriples, err := store.GetValueTriples(env, label, exact)
+	valueTriples, err := storemod.GetTripleModels[*model.ValueTriple](store, env, label, exact, false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting value triples: %w", err)
 	}

--- a/test/test.bats
+++ b/test/test.bats
@@ -25,7 +25,7 @@ function do_get() {
     config_path=$1
 
      $CORIM_STORE --config "$config_path" corim add "$ROOT_DIR"/sample/corim/*cbor &>/dev/null
-     $CORIM_STORE --config "$config_path" get --class-id psa.impl-id:f0VMRgIBAQAAAAAAAAAAAAMAPgABAAAAUFgAAAAAAAA=
+     $CORIM_STORE --config "$config_path" get --class-id psa.impl-id:2QJYWCB/RUxGAgEBAAAAAAAAAAAAAwA+AAEAAABQWAAAAAAAAA==
 }
 
 @test "SQLite3 get" {


### PR DESCRIPTION
This is a follow up to the previous commit. This updates the return values of the store API to be comid types as well. Again, the reasoning is that the model types are specific to the SQL implementation of the Store interface, and external callers will basically always want the comid types.

However, internal callers (the CLI commands) are easier to implement using the model types. To help this (plus give the option in case some external caller does ant models as well), the previously-internal getTriples() generic function has been promoted to exported GetTripleModels(). Command implements are now using that, rather then the Store get methods.