### PR TITLE
fix(coserv)!: default Expiry

### DIFF
--- a/pkg/store/coserv.go
+++ b/pkg/store/coserv.go
@@ -21,11 +21,15 @@ type CoSERVService struct {
 	// FallbackAuthority authority will be used when no other authority can
 	// be established for result data.
 	FallbackAuthority *comid.CryptoKey
+	// DefaultExpiry is the duration (from when a result is generated) that
+	// will be used to set the Expiry of the result if one could not be
+	// established from the manifests used to construct the result.
+	DefaultExpiry time.Duration
 }
 
 // NewCoSERVService creates a new instance of the service.
-func NewCoSERVService(store *Store, authority *comid.CryptoKey) *CoSERVService {
-	return &CoSERVService{store, authority}
+func NewCoSERVService(store *Store, authority *comid.CryptoKey, defaultExpiry time.Duration) *CoSERVService {
+	return &CoSERVService{store, authority, defaultExpiry}
 }
 
 // UpdateCoSERV runs the query inside the provided coserv.Coserv object and
@@ -134,6 +138,8 @@ func (o *CoSERVService) RunQuery(profile *eat.Profile, query *coserv.Query) (*co
 
 	if expiry != nil {
 		result.SetExpiry(*expiry)
+	} else {
+		result.SetExpiry(time.Now().Add(o.DefaultExpiry))
 	}
 
 	return result, nil

--- a/pkg/store/coserv_test.go
+++ b/pkg/store/coserv_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +33,7 @@ func TestCoSERVService(t *testing.T) {
 	authority, err := comid.NewCryptoKeyTaggedBytes("test")
 	require.NoError(t, err)
 
-	service := NewCoSERVService(store, authority)
+	service := NewCoSERVService(store, authority, 5*time.Minute)
 
 	profile, err := eat.NewProfile("http://example.com")
 	require.NoError(t, err)
@@ -194,4 +195,59 @@ func TestCoSERVService(t *testing.T) {
 
 	err = service.UpdateCoSERV(cs)
 	assert.ErrorIs(t, err, ErrMeasuments)
+}
+
+func TestCoSERVService_expiry(t *testing.T) {
+	ctx := context.Background()
+	db := model.NewTestDBWithFixtures(t, map[string][]byte{
+		"cryptokeys.yaml":         cryptoKeysFixture,
+		"digests.yaml":            digestsFixture,
+		"manifests.yaml":          manifestsFixture,
+		"module_tags.yaml":        moduleTagsFixture,
+		"triples.yaml":            triplesFixture,
+		"environments.yaml":       environmentsFixture,
+		"measurements.yaml":       measurementsFixture,
+		"measurement_values.yaml": measurementValuesFixture,
+	})
+	defer func() { assert.NoError(t, db.Close()) }()
+
+	_, err := db.Exec("UPDATE manifests SET not_before = NULL, not_after = NULL")
+	require.NoError(t, err)
+
+	store, err := OpenWithDB(ctx, db)
+	require.NoError(t, err)
+
+	authority, err := comid.NewCryptoKeyTaggedBytes("test")
+	require.NoError(t, err)
+
+	service := NewCoSERVService(store, authority, 5*time.Minute)
+
+	profile, err := eat.NewProfile("http://example.com")
+	require.NoError(t, err)
+
+	name := "foo"
+
+	cs := &coserv.Coserv{
+		Profile: *profile,
+		Query: coserv.Query{
+			ArtifactType: coserv.ArtifactTypeReferenceValues,
+			EnvironmentSelector: *coserv.NewEnvironmentSelector().
+				AddClass(coserv.StatefulClass{
+					Class: comid.NewClassBytes([]byte{
+						0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+						0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+						0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+						0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+					}),
+					Measurements: comid.NewMeasurements().Add(&comid.Measurement{
+						Val: comid.Mval{Name: &name},
+					}),
+				}),
+			ResultType: coserv.ResultTypeCollectedArtifacts,
+		},
+	}
+
+	err = service.UpdateCoSERV(cs)
+	assert.NoError(t, err)
+	assert.NotNil(t, cs.Results.Expiry)
 }


### PR DESCRIPTION
Handle the case where expiry cannot be established from the manifests used to construct a CoSERV result set by falling back to a fixed offset from the time the result was constructed. The offset is specified on construction of the CoSERVService.

BREAKING CHANGE: NewCoSERVService() has been updated to take a mandatory time.Duration argument specifying the default expiry.

Addresses: https://github.com/veraison/corim-store/issues/19